### PR TITLE
unspeat output overflow fix for mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 plan.md
+/AGENTS.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "sikka",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/public/wallet/index.html
+++ b/public/wallet/index.html
@@ -83,10 +83,10 @@
               <span class="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-xs font-semibold text-slate-300">{{ matureUtxoCount }} spendable · {{ immatureUtxoCount }} maturing</span>
             </div>
             <div class="mt-4 grid gap-3">
-              <a v-for="(utxo, index) in utxos" :key="utxo.txid + ':' + utxo.index + ':' + index" :href="'/tx/' + encodeURIComponent(utxo.txid)" class="block rounded-[1.25rem] border border-white/10 bg-white/[0.03] px-4 py-4 ring-1 ring-white/5 transition hover:border-sky-200/35 hover:bg-sky-200/5">
-                <div class="flex flex-wrap items-center gap-3">
-                  <p class="font-mono text-xs text-sky-200 sm:text-sm">{{ utxo.txid }}</p>
-                  <span class="rounded-full border border-cyan-300/20 bg-cyan-300/10 px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] text-cyan-200">{{ formatSikka(utxo.value) }} SIKKA</span>
+              <a v-for="(utxo, index) in utxos" :key="utxo.txid + ':' + utxo.index + ':' + index" :href="'/tx/' + encodeURIComponent(utxo.txid)" class="block min-w-0 overflow-hidden rounded-[1.25rem] border border-white/10 bg-white/[0.03] px-4 py-4 ring-1 ring-white/5 transition hover:border-sky-200/35 hover:bg-sky-200/5">
+                <div class="flex min-w-0 flex-wrap items-center gap-3">
+                  <p class="min-w-0 break-all font-mono text-xs text-sky-200 sm:text-sm">{{ utxo.txid }}</p>
+                  <span class="max-w-full rounded-full border border-cyan-300/20 bg-cyan-300/10 px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] text-cyan-200">{{ formatSikka(utxo.value) }} SIKKA</span>
                   <span :class="utxoMaturityBadgeClass(utxo)" :title="utxoMaturityDetail(utxo)">{{ utxoMaturityLabel(utxo) }}</span>
                 </div>
                 <div class="mt-3 flex flex-wrap gap-x-4 gap-y-2 text-xs text-slate-400 sm:text-sm">


### PR DESCRIPTION
Fixed overflow of content on mobile device for **Unspent Outputs**
Before fix: 
<img width="330" height="681" alt="image" src="https://github.com/user-attachments/assets/23204233-871d-4779-80d0-4990812085a9" />

After fix: 
(Mob):
<img width="328" height="674" alt="image" src="https://github.com/user-attachments/assets/fe88d64b-864f-4931-a58b-363c762949a6" />
(Desktoop):
<img width="1329" height="737" alt="image" src="https://github.com/user-attachments/assets/7db585c7-c141-4f94-b7b6-9c6baee858a2" />
