### PR TITLE
Attest weak-subjectivity pins from bootstrap nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,7 +1332,7 @@ dependencies = [
 
 [[package]]
 name = "sikka-checkpoint"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "redb",
  "sikka-common",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "sikka-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "serde",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "sikka-common"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "hex",
  "serde",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "sikka-consensus"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1383,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "sikka-crypto"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "fips204",
  "hex",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "sikka-node"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "sikka-onion"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "sikka-p2p"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "hex",
  "reqwest",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "sikka-rpc"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "reqwest",
  "serde",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "sikka-state"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "hex",
  "redb",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "sikka-wallet"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "hex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/sikkalabs/sikka"

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /data
 VOLUME ["/data"]
 EXPOSE 64552
 
-# Node knobs: SIKKA_PRIVATE_KEY, SIKKA_TRUSTED_CHECKPOINT, SIKKA_LOG.
+# Node knobs: SIKKA_PRIVATE_KEY, SIKKA_TRUSTED_CHECKPOINT (optional), SIKKA_LOG.
 # SIKKA_KEYSTORE / SIKKA_NODE are for the in-container `sikka` CLI only.
 ENV SIKKA_LOG=info \
     SIKKA_KEYSTORE=/data/node_key.json \

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -65,13 +65,14 @@ pub const DEFAULT_MAX_MISSED_PROPOSER_SLOTS: u32 = 100;
 /// Number of recent checkpoints retained; older ones are pruned.
 pub const CHECKPOINT_HISTORY: u64 = 100;
 
-/// Maximum height gap a node may fast-sync across without an independently
-/// pinned trusted checkpoint.
+/// Maximum height gap a node may fast-sync across without a trust pin.
 ///
-/// A gap of one height can still be closed by replaying a finalized checkpoint.
-/// Anything larger requires `SIKKA_TRUSTED_CHECKPOINT`, even when
-/// `validator_root` is unchanged — otherwise a former ≥2/3 set can forge a
-/// long-range fork that keeps the same root and trick a stale node.
+/// A gap of one height can still be closed by replaying a finalized checkpoint
+/// against the locally known validator set. Anything larger needs a pin: an
+/// operator `SIKKA_TRUSTED_CHECKPOINT`, or a hash attested by the hardcoded
+/// bootstrap nodes. Unattested snapshots from ordinary gossip peers are never
+/// enough — otherwise a former ≥2/3 set can forge a long-range fork and trick
+/// a stale node.
 pub const WEAK_SUBJECTIVITY_GAP: u64 = 1;
 
 /// Votes more than this many heights ahead of the local tip are ignored.

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -1,9 +1,11 @@
 //! Node configuration.
 //!
-//! Operator env knobs (Docker): `SIKKA_PRIVATE_KEY`, `SIKKA_TRUSTED_CHECKPOINT`,
-//! `SIKKA_LOG`. Everything else is fixed for the image (`/data`, Tor SOCKS,
-//! baked-in bootstrap onions). Advertise URL is always the deterministic Tor
-//! onion derived from the node key.
+//! Operator env knobs (Docker): `SIKKA_PRIVATE_KEY`, `SIKKA_TRUSTED_CHECKPOINT`
+//! (optional override), `SIKKA_LOG`. Everything else is fixed for the image
+//! (`/data`, Tor SOCKS, baked-in bootstrap onions). Advertise URL is always
+//! the deterministic Tor onion derived from the node key. Multi-height
+//! fast-sync pins come from those bootstrap onions unless the operator sets
+//! `SIKKA_TRUSTED_CHECKPOINT`.
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
@@ -59,7 +61,8 @@ pub struct NodeConfig {
     /// Timeout for large peer transfers (proposals, finalized checkpoints,
     /// mempool sync, snapshots).
     pub bulk_request_timeout: Duration,
-    /// Required trust anchor when a multi-height snapshot changes validators.
+    /// Optional operator override for the weak-subjectivity pin. When unset,
+    /// hardcoded bootstrap nodes attest the live tip for multi-height sync.
     pub trusted_checkpoint: Option<TrustedCheckpoint>,
     /// Seal a checkpoint after this long even if the pool is short of a full
     /// batch, so a quiet chain still makes progress. Zero disables it.

--- a/crates/node/src/loops.rs
+++ b/crates/node/src/loops.rs
@@ -199,7 +199,7 @@ async fn catchup_loop(node: Arc<Node>, gossip: Arc<Gossip>, client: PeerClient) 
     match sync::fast_sync(&node, &client).await {
         Ok(Some(height)) => info!(height, "synced at startup"),
         Ok(None) => debug!("already at the network's height"),
-        Err(e) => debug!(error = %e, "nothing to sync from at startup"),
+        Err(e) => warn!(error = %e, "startup fast-sync failed"),
     }
 
     let mut ticker = ticker(Duration::from_secs(15));

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -47,7 +47,7 @@ use sikka_state::{
 };
 use sikka_wallet::Keystore;
 
-use crate::config::NodeConfig;
+use crate::config::{NodeConfig, TrustedCheckpoint};
 
 /// A finalized checkpoint and the transactions (plus slashing evidence) that
 /// produced it.
@@ -148,6 +148,9 @@ pub struct Node {
     snapshot_building: Arc<AtomicBool>,
     /// Cached Tor reachability for the landing page / chain.info.
     tor_status: Mutex<TorInfo>,
+    /// Weak-subjectivity pin learned from hardcoded bootstrap nodes. Operator
+    /// `SIKKA_TRUSTED_CHECKPOINT` still wins when both are set.
+    attested_checkpoint: Mutex<Option<TrustedCheckpoint>>,
     started_at: u64,
 }
 
@@ -267,6 +270,7 @@ impl Node {
             funded_address_cache: Mutex::new(None),
             snapshot_building: Arc::new(AtomicBool::new(false)),
             tor_status: Mutex::new(initial_tor_status(&config)),
+            attested_checkpoint: Mutex::new(None),
             started_at: now,
             config,
         });
@@ -1727,7 +1731,7 @@ impl Node {
         }
 
         let checkpoint_hash = checkpoint.hash();
-        let pinned = match self.config.trusted_checkpoint {
+        let pinned = match self.effective_trusted_checkpoint() {
             Some(anchor) if anchor.height == height => {
                 if anchor.hash != checkpoint_hash {
                     return Err(Error::Other(format!(
@@ -1744,8 +1748,9 @@ impl Node {
         if gap > sikka_common::constants::WEAK_SUBJECTIVITY_GAP && !pinned {
             return Err(Error::Other(format!(
                 "snapshot gap from {local_height} to {height} exceeds weak-subjectivity \
-                 limit {}; set SIKKA_TRUSTED_CHECKPOINT={height}:{checkpoint_hash} after \
-                 independently verifying that checkpoint{}",
+                 limit {}; hardcoded bootstrap nodes could not attest this tip — set \
+                 SIKKA_TRUSTED_CHECKPOINT={height}:{checkpoint_hash} after independently \
+                 verifying that checkpoint{}",
                 sikka_common::constants::WEAK_SUBJECTIVITY_GAP,
                 if validators_changed {
                     " (validator set also changed)"
@@ -1755,6 +1760,59 @@ impl Node {
             )));
         }
         Ok(pinned)
+    }
+
+    /// Operator pin, or a pin learned from bootstrap attestation.
+    pub fn effective_trusted_checkpoint(&self) -> Option<TrustedCheckpoint> {
+        self.config
+            .trusted_checkpoint
+            .or_else(|| *self.attested_checkpoint.lock())
+    }
+
+    pub fn set_attested_checkpoint(&self, pin: TrustedCheckpoint) {
+        *self.attested_checkpoint.lock() = Some(pin);
+    }
+
+    /// Decide whether a bootstrap's latest checkpoint can authorize a snapshot pin.
+    ///
+    /// `Ok(true)` — same validator root as us, signatures verify against the
+    /// locally known set. `Ok(false)` — validator set changed, so this hash is
+    /// only a social claim. `Err` — wrong chain, not ahead, or a same-root
+    /// checkpoint whose signatures do not check out.
+    pub fn evaluate_bootstrap_checkpoint(&self, checkpoint: &Checkpoint) -> Result<bool> {
+        let chain = self.chain();
+        let meta = chain.ledger.meta();
+        if checkpoint.header.genesis_fingerprint != meta.genesis_fingerprint {
+            return Err(Error::GenesisMismatch);
+        }
+        if checkpoint.header.chain_id != meta.chain_id {
+            return Err(Error::ChainIdMismatch {
+                expected: meta.chain_id.clone(),
+                actual: checkpoint.header.chain_id.clone(),
+            });
+        }
+        let local_height = chain.ledger.height();
+        let height = checkpoint.header.height;
+        if height <= local_height {
+            return Err(Error::Other(format!(
+                "bootstrap checkpoint at height {height} is not ahead of local height {local_height}"
+            )));
+        }
+        if checkpoint.header.validator_root != chain.ledger.validator_root() {
+            return Ok(false);
+        }
+        let validators = chain.ledger.validators()?;
+        let authorized: Vec<(Address, PublicKey, u64)> = validators
+            .iter()
+            .filter(|validator| validator.is_active_at(height))
+            .map(|validator| (validator.address, validator.public_key.clone(), validator.bond))
+            .collect();
+        if authorized.is_empty() {
+            return Err(Error::NoActiveValidators);
+        }
+        checkpoint
+            .verify_signatures(authorized.iter().map(|(address, key, bond)| (address, key, *bond)))?;
+        Ok(true)
     }
 
     /// Validate a manifest's chain identity and trust anchor before downloading
@@ -1803,8 +1861,8 @@ impl Node {
         )?;
 
         // A one-height transition is authorized by the locally known active
-        // set. Larger gaps always need an operator-pinned trust anchor (see
-        // WEAK_SUBJECTIVITY_GAP), even when validator_root is unchanged.
+        // set. Larger gaps need a pin: operator `SIKKA_TRUSTED_CHECKPOINT` or
+        // a hash attested by the hardcoded bootstrap nodes.
         let validators: Vec<Validator> = if pinned {
             snapshot.validators.clone()
         } else {

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -9,15 +9,19 @@
 //! are the same operation, and both cost the size of the current state rather
 //! than the size of all history.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use tracing::{debug, info, warn};
 
+use sikka_common::bytes::Hash;
+use sikka_common::constants::WEAK_SUBJECTIVITY_GAP;
 use sikka_common::error::{Error, Result};
 use sikka_p2p::client::PeerClient;
 use sikka_p2p::validate_endpoint_url;
 use sikka_state::{SnapshotDownload, SnapshotManifest};
 
+use crate::config::TrustedCheckpoint;
 use crate::node::Node;
 
 /// A peer's self-reported position.
@@ -26,6 +30,14 @@ pub struct PeerStatus {
     pub endpoint: String,
     pub height: u64,
     pub chain_id: String,
+}
+
+/// A latest-checkpoint claim from a hardcoded bootstrap node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BootstrapCandidate {
+    height: u64,
+    hash: Hash,
+    locally_verifiable: bool,
 }
 
 /// Poll peers for their height, dropping the ones on a different chain.
@@ -62,6 +74,94 @@ pub async fn survey(node: &Arc<Node>, client: &PeerClient) -> Vec<PeerStatus> {
     statuses
 }
 
+/// Learn a weak-subjectivity pin from the hardcoded bootstrap list.
+///
+/// Discovered gossip peers never participate: a random onion in the peer book
+/// must not choose the canonical hash. Bootstrap onions are already in the
+/// binary as the discovery roots, so they are the social-consensus source for
+/// "which finalized checkpoint is the live tip."
+///
+/// Same validator root as genesis (or our last known set): one bootstrap whose
+/// checkpoint signatures verify is enough — forging that requires the live
+/// ≥2/3 keys, which can already finalize the chain. Validator-set changes
+/// cannot be checked locally, so those hashes need a 2/3 majority of the
+/// *configured* bootstrap list to agree. Distinct hashes at the same height
+/// are equivocation and refuse to guess.
+async fn attest_from_bootstraps(
+    node: &Arc<Node>,
+    client: &PeerClient,
+) -> Result<Option<TrustedCheckpoint>> {
+    let bootstraps = node.config().bootstrap.clone();
+    if bootstraps.is_empty() {
+        return Ok(None);
+    }
+    let advertise = node.config().advertise.clone();
+    let mut candidates = Vec::new();
+    for endpoint in &bootstraps {
+        if endpoint == &advertise {
+            continue;
+        }
+        match client.latest_checkpoint(endpoint).await {
+            Ok(checkpoint) => match node.evaluate_bootstrap_checkpoint(&checkpoint) {
+                Ok(locally_verifiable) => {
+                    candidates.push(BootstrapCandidate {
+                        height: checkpoint.header.height,
+                        hash: checkpoint.hash(),
+                        locally_verifiable,
+                    });
+                }
+                Err(e) => {
+                    debug!(
+                        peer = %endpoint,
+                        error = %e,
+                        "bootstrap checkpoint is not a usable trust anchor"
+                    );
+                }
+            },
+            Err(e) => {
+                debug!(peer = %endpoint, error = %e, "bootstrap checkpoint fetch failed");
+            }
+        }
+    }
+    select_attested_checkpoint(&candidates, bootstraps.len())
+}
+
+fn select_attested_checkpoint(
+    candidates: &[BootstrapCandidate],
+    configured_bootstrap_count: usize,
+) -> Result<Option<TrustedCheckpoint>> {
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+    let max_height = candidates.iter().map(|c| c.height).max().unwrap();
+    let at_tip: Vec<&BootstrapCandidate> = candidates
+        .iter()
+        .filter(|c| c.height == max_height)
+        .collect();
+    let mut hashes = HashSet::new();
+    for candidate in &at_tip {
+        hashes.insert(candidate.hash);
+    }
+    if hashes.len() > 1 {
+        return Err(Error::Other(format!(
+            "bootstrap nodes disagree on the checkpoint hash at height {max_height}; \
+             set SIKKA_TRUSTED_CHECKPOINT after independently verifying the canonical tip"
+        )));
+    }
+    let hash = at_tip[0].hash;
+    let locally_verifiable = at_tip.iter().any(|c| c.locally_verifiable);
+    if !locally_verifiable {
+        let needed = (2 * configured_bootstrap_count).div_ceil(3).max(1);
+        if at_tip.len() < needed {
+            return Ok(None);
+        }
+    }
+    Ok(Some(TrustedCheckpoint {
+        height: max_height,
+        hash,
+    }))
+}
+
 /// Bring this node up to the network's height using a snapshot.
 ///
 /// Returns the height reached, or `None` if nobody is ahead of us.
@@ -73,6 +173,27 @@ pub async fn fast_sync(node: &Arc<Node>, client: &PeerClient) -> Result<Option<u
     };
     if best.height <= local {
         return Ok(None);
+    }
+
+    let gap = best.height.saturating_sub(local);
+    if gap > WEAK_SUBJECTIVITY_GAP && node.config().trusted_checkpoint.is_none() {
+        match attest_from_bootstraps(node, client).await {
+            Ok(Some(pin)) => {
+                node.set_attested_checkpoint(pin);
+                info!(
+                    height = pin.height,
+                    hash = %pin.hash,
+                    "bootstrap-attested weak-subjectivity pin"
+                );
+            }
+            Ok(None) => {
+                debug!("hardcoded bootstrap nodes did not attest a weak-subjectivity pin");
+            }
+            Err(e) => {
+                warn!(error = %e, "bootstrap checkpoint attestation failed");
+                return Err(e);
+            }
+        }
     }
 
     info!(from = local, to = best.height, peer = %best.endpoint, "fast syncing");
@@ -91,7 +212,9 @@ pub async fn fast_sync(node: &Arc<Node>, client: &PeerClient) -> Result<Option<u
         };
         if let Err(e) = node.verify_snapshot_manifest(&manifest) {
             warn!(peer = %status.endpoint, error = %e, "rejected a peer's snapshot manifest");
-            node.record_peer_failure(&status.endpoint);
+            // Policy rejects (weak-subjectivity, wrong hash) are not evidence
+            // that the peer is unreachable — a lagging honest node still serves
+            // a real snapshot of an older height.
             last_error = Some(e);
             continue;
         }
@@ -134,9 +257,10 @@ pub async fn fast_sync(node: &Arc<Node>, client: &PeerClient) -> Result<Option<u
 /// Discard a peer's failed snapshot download so failed syncs cannot stack up
 /// on disk (the original reason the sync endpoint was a cheap DoS).
 fn cleanup_snapshot(node: &Node, manifest: &SnapshotManifest) {
-    if let Err(error) =
-        SnapshotDownload::remove_for(node.config().snapshot_download_path(), &manifest.snapshot_id)
-    {
+    if let Err(error) = SnapshotDownload::remove_for(
+        node.config().snapshot_download_path(),
+        &manifest.snapshot_id,
+    ) {
         debug!(%error, snapshot = %manifest.snapshot_id, "could not clean up failed snapshot download");
     }
 }
@@ -214,4 +338,62 @@ pub async fn gossip_mempool(node: &Arc<Node>, client: &PeerClient) -> usize {
         }
     }
     accepted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cand(height: u64, byte: u8, locally_verifiable: bool) -> BootstrapCandidate {
+        BootstrapCandidate {
+            height,
+            hash: Hash([byte; 32]),
+            locally_verifiable,
+        }
+    }
+
+    #[test]
+    fn a_lagging_bootstrap_does_not_block_the_tip() {
+        let pin = select_attested_checkpoint(&[cand(146, 1, true), cand(912, 2, true)], 2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(pin.height, 912);
+        assert_eq!(pin.hash, Hash([2; 32]));
+    }
+
+    #[test]
+    fn one_locally_verified_bootstrap_is_enough() {
+        let pin = select_attested_checkpoint(&[cand(912, 7, true)], 2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(pin.height, 912);
+        assert_eq!(pin.hash, Hash([7; 32]));
+    }
+
+    #[test]
+    fn validator_set_change_needs_bootstrap_quorum() {
+        assert!(select_attested_checkpoint(&[cand(50, 3, false)], 2)
+            .unwrap()
+            .is_none());
+        let pin = select_attested_checkpoint(&[cand(50, 3, false), cand(50, 3, false)], 2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(pin.height, 50);
+        assert_eq!(pin.hash, Hash([3; 32]));
+    }
+
+    #[test]
+    fn equivocating_bootstraps_refuse_to_guess() {
+        let error =
+            select_attested_checkpoint(&[cand(912, 1, true), cand(912, 2, true)], 2).unwrap_err();
+        assert!(
+            error.to_string().contains("disagree"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn empty_candidates_mean_no_pin() {
+        assert!(select_attested_checkpoint(&[], 2).unwrap().is_none());
+    }
 }

--- a/crates/node/tests/testnet.rs
+++ b/crates/node/tests/testnet.rs
@@ -176,8 +176,9 @@ impl Testnet {
 
     /// Add a node that is not a validator and has no state at all.
     ///
-    /// `trusted` is required when the network tip is more than one height ahead
-    /// of genesis (weak-subjectivity window).
+    /// Bootstraps the joiner with every running node so it can attest a
+    /// weak-subjectivity pin the same way production joiners use the hardcoded
+    /// genesis onions. Pass `trusted` only to override that attestation.
     async fn join_observer(&self, trusted: Option<TrustedCheckpoint>) -> TestNode {
         let bootstrap: Vec<String> = self.nodes.iter().map(|n| n.endpoint.clone()).collect();
         spawn_node(&self.genesis_path, None, bootstrap, false, trusted).await
@@ -440,16 +441,11 @@ async fn a_new_node_joins_and_fast_syncs_to_the_current_state() {
     }
     let target = net.nodes[0].node.height();
     assert!(target >= 3);
-    let tip = net.nodes[0].node.checkpoint(target).unwrap();
 
-    // A node with an empty database joins with an independently pinned tip —
-    // multi-height snapshot sync always needs a weak-subjectivity checkpoint.
-    let joiner = net
-        .join_observer(Some(TrustedCheckpoint {
-            height: tip.header.height,
-            hash: tip.hash(),
-        }))
-        .await;
+    // A node with an empty database joins with no operator pin. The live
+    // validators are its bootstrap list, so they attest the tip the same way
+    // production joiners learn a pin from the hardcoded genesis onions.
+    let joiner = net.join_observer(None).await;
     assert_eq!(joiner.node.height(), 0, "a joiner starts from genesis");
 
     let deadline = Instant::now() + Duration::from_secs(30);

--- a/docs/api.md
+++ b/docs/api.md
@@ -302,10 +302,11 @@ The old monolithic `GET /api/state/snapshot` JSON response no longer exists.
 
 Snapshot chunks prove their contents against the checkpoint roots, but they do
 not prove an arbitrary history against a long-range fork. A node accepts an
-unpinned snapshot only across a single-height gap. Any larger gap requires an
-independently verified
-`SIKKA_TRUSTED_CHECKPOINT=<height>:<checkpoint-hash>` trust anchor — even when
-the validator root is unchanged.
+unpinned snapshot from an ordinary gossip peer only across a single-height gap.
+Any larger gap needs a pin: the hardcoded bootstrap onions attest the live tip
+automatically (see the whitepaper §16.2). `SIKKA_TRUSTED_CHECKPOINT=<height>:<checkpoint-hash>`
+is the operator override when bootstraps disagree or the validator set has
+changed without a bootstrap quorum.
 
 ---
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -56,7 +56,9 @@ open http://127.0.0.1:64552/wallet.html  # browser wallet on this node
 ```
 
 Joiners: different `--name`, volume, and seed. Peers find each other over Tor
-via the hardcoded onion bootstrap.
+via the hardcoded onion bootstrap. A joiner that starts at genesis learns the
+live checkpoint hash from those same bootstrap onions — you do not set
+`SIKKA_TRUSTED_CHECKPOINT` for a normal join.
 
 ### Local Tor mesh test (two validators)
 
@@ -126,7 +128,7 @@ docker exec sikka sikka help
 | Variable | Default in image | Meaning |
 | --- | --- | --- |
 | `SIKKA_PRIVATE_KEY` | unset | 32-byte seed or full secret (hex); else a key is created under `/data` |
-| `SIKKA_TRUSTED_CHECKPOINT` | unset | `<height>:<hash>` trust anchor required when fast-sync crosses more than one height |
+| `SIKKA_TRUSTED_CHECKPOINT` | unset | optional `<height>:<hash>` override; joiners normally learn the pin from the hardcoded bootstrap onions |
 | `SIKKA_LOG` | `info` | tracing filter |
 
 Paths, Tor SOCKS (`127.0.0.1:9050`), and bootstrap peers are fixed in the image.
@@ -135,10 +137,9 @@ Optional custom genesis: drop a file at `/data/genesis.json` (otherwise baked-in
 `SIKKA_KEYSTORE` / `SIKKA_NODE` are set in the image for the in-container
 `sikka` CLI (`docker exec sikka sikka …`), not for `sikka-node` itself.
 
-Do not copy `SIKKA_TRUSTED_CHECKPOINT` from an untrusted peer. Verify the
-checkpoint hash independently through multiple operators or a release
-announcement first. Any gap beyond one height needs a pin, even when the
-validator root is unchanged.
+Leave `SIKKA_TRUSTED_CHECKPOINT` unset unless bootstrap nodes disagree on the
+tip or you are restoring from a known hash. Do not copy a checkpoint hash from
+an untrusted gossip peer.
 
 ---
 

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -941,10 +941,27 @@ anyway, because history is gone.
 
 ### 16.2 Weak subjectivity
 
-A node accepts an unpinned snapshot only across a **single-height gap**
-(`WEAK_SUBJECTIVITY_GAP = 1`). Anything larger requires an operator-pinned
-`SIKKA_TRUSTED_CHECKPOINT=<height>:<hash>` — even when the validator root is
-unchanged — otherwise a former ≥2/3 set could forge a long-range fork.
+A node accepts an unpinned snapshot from an ordinary gossip peer only across a
+**single-height gap** (`WEAK_SUBJECTIVITY_GAP = 1`). Anything larger needs a
+pin, otherwise a former ≥2/3 set could forge a long-range fork.
+
+The pin is normally **attested by the hardcoded bootstrap onions** already in
+the binary (the same nodes used for first contact). A joiner asks those onions
+for `checkpoint/latest`, keeps the highest height, and:
+
+- if that checkpoint still has the locally known `validator_root` and its
+  signatures verify against the local set, one honest bootstrap is enough —
+  forging it requires the live ≥2/3 keys, which can already finalize the chain;
+- if the validator set has changed, a ≥2/3 majority of the *configured*
+  bootstrap list must agree on the hash (they are making a social claim the
+  joiner cannot check locally);
+- if bootstraps publish distinct hashes at the same height, the node refuses
+  to guess.
+
+`SIKKA_TRUSTED_CHECKPOINT=<height>:<hash>` remains an operator override for
+bootstrap disagreement, a validator-set transition the bootstraps have not
+yet attested, or an air-gapped restore. Do not copy that hash from an
+untrusted peer.
 
 ### 16.3 Stateless, verifiable wallets
 
@@ -993,7 +1010,7 @@ multi-receive is left to wallets you write yourself (see `docs/wallets.md`).
 | Transaction spam | per-account battery (+1/min, cap 10, 1/tx); fresh accounts start empty |
 | Sybil funding → spam | newly funded accounts start at 0 battery; genesis accounts start full (cannot be minted) |
 | Equivocation / double-signing | the only slashable offence; bond burned on proof |
-| Long-range fork | weak-subjectivity gap = 1; `SIKKA_TRUSTED_CHECKPOINT` pin |
+| Long-range fork | weak-subjectivity gap = 1; bootstrap-attested pin (manual `SIKKA_TRUSTED_CHECKPOINT` as override) |
 | Proposer front-running / reordering | canonical order `(from, nonce, id)`; replay produces identical roots |
 | Unsigned-CPU DoS on proposals | proposer signature verified *before* per-tx ML-DSA work |
 | Vote flood DoS | votes only tracked ≤ 1 height ahead; ML-DSA verified on arrival |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Joiners that start at genesis (or fall more than one height behind) could not snapshot-sync without a hand-copied `SIKKA_TRUSTED_CHECKPOINT`. On the live mesh that left onions such as `ntrsxw2…` stuck at height 0 with healthy Tor, 8 peers, and matching genesis — while validator 1 was at 912.

A gap > 1 still needs a pin (long-range / former-set forks). The pin is now **attested by the hardcoded bootstrap onions** already in the binary, which are the same social-consensus roots used for first contact.

## Behaviour

On fast-sync, if the gap exceeds `WEAK_SUBJECTIVITY_GAP` and the operator did not set a pin:

1. Ask each configured bootstrap for `GET /api/checkpoint/latest` (not discovered gossip peers).
2. Take the highest height.
3. Same `validator_root` as local state, signatures verify → one honest bootstrap is enough (forging it needs the live ≥2/3 keys).
4. Validator set changed → ≥2/3 of the *configured* bootstrap list must agree on the hash.
5. Distinct hashes at the same height → refuse to guess; operator pin still required.

`SIKKA_TRUSTED_CHECKPOINT` remains an override. A lagging bootstrap (e.g. height 146 vs 912) does not block the tip.

## Tests

- Joiner with no operator pin catches up via bootstrap attestation.
- Validator-set-changing snapshot with an empty bootstrap list still requires a pin.
- Unit tests for lagging bootstrap, single verified bootstrap, set-change quorum, and equivocation.

Version bumped to 0.3.2. After this image is running, recreate the stuck joiner **without** a pin; it should log `bootstrap-attested weak-subjectivity pin` and sync.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25cb55c5-0f1c-4293-85de-dbc7357b054e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25cb55c5-0f1c-4293-85de-dbc7357b054e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

